### PR TITLE
run in local network

### DIFF
--- a/src/WebSocketClient.ts
+++ b/src/WebSocketClient.ts
@@ -30,7 +30,7 @@ export default class Client<T> extends events.EventEmitter {
   _createClient(): WebSocket {
     this.syncState = Automerge.initSyncState()
     // TODO: add peerId /documentId/peerId
-    this.client = new WebSocket(`ws://localhost:8080/${this.documentId}`, 'echo-protocol');
+    this.client = new WebSocket(`ws://${window.location.hostname}:8080/${this.documentId}`, 'echo-protocol');
     this.client.binaryType = 'arraybuffer';
 
     this.client.onerror = () => {


### PR DESCRIPTION
this.client = new WebSocket(`ws://${window.location.hostname}:8080/${this.documentId}`, 'echo-protocol');

instead of localhost
because localhost:8080 can not be accessed by other computer on the same network